### PR TITLE
Modify tap.swift for Swift 3.1

### DIFF
--- a/tap/tap.swift
+++ b/tap/tap.swift
@@ -43,8 +43,8 @@ open class TAP {
     @discardableResult
     open func eq<T:Equatable>(_ actual:T?, _ expected:T?, _ message:String = "")->Bool {
         if ok(actual == expected, message) { return true }
-        print("#       got: \(actual)")
-        print("#  expected: \(expected)")
+        print("#       got: \(actual as T?)")
+        print("#  expected: \(expected as T?)")
         return false
     }
     /// ok if arrays are `actual` == `expected`
@@ -75,8 +75,8 @@ open class TAP {
     @discardableResult
     open func ne<T:Equatable>(_ actual:T?, _ expected:T?, _ message:String = "")->Bool {
         if ok(actual != expected, message) { return true }
-        print("#       got: \(actual)")
-        print("#  expected: anthing but \(expected)")
+        print("#       got: \(actual as T?)")
+        print("#  expected: anthing but \(expected as T?)")
         return false
     }
     /// ok if arrays are `actual` == `expected`


### PR DESCRIPTION
I believe it is desirable to avoid bothering warnings such as "string interpolation produces a debug description for an optional value; did you mean to make this explicit?" in Swift 3.1